### PR TITLE
initial implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,33 +3,48 @@ cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 project(rttest)
 
 set(CMAKE_CXX_FLAGS "-std=c++11")
-set(INSTALL_LIB_DIR lib CACHE PATH "install dir for libraries")
-set(INSTALL_BIN_DIR bin CACHE PATH "install dir for executables")
-set(INSTALL_INCLUDE_DIR include/rttest CACHE PATH "install dir for headers")
 
-set(DEF_INSTALL_CMAKE_DIR lib/cmake/rttest)
-set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "install dir for cmake files")
+find_package(ament_cmake_auto QUIET)
 
-add_library(rttest ${PROJECT_SOURCE_DIR}/src/rttest.cpp)
+# ament build if it was found
+if(${ament_cmake_auto_FOUND})
+  ament_auto_find_build_dependencies()
+  ament_auto_add_library(rttest ${PROJECT_SOURCE_DIR}/src/rttest.cpp)
+  include_directories(rttest ${PROJECT_SOURCE_DIR}/include/rttest)
+  #ament_auto_package(CONFIG_EXTRAS ${CMAKE_PROJECT_NAME}Config.cmake)
 
-include_directories(rttest ${PROJECT_SOURCE_DIR}/include/rttest)
+else()
+  message(STATUS "ament_cmake_auto not found, executing pure CMake build")
+  # pure cmake build
+  set(INSTALL_LIB_DIR lib CACHE PATH "install dir for libraries")
+  set(INSTALL_BIN_DIR bin CACHE PATH "install dir for executables")
+  set(INSTALL_INCLUDE_DIR include/rttest CACHE PATH "install dir for headers")
 
-install(TARGETS rttest
-  LIBRARY DESTINATION ${INSTALL_LIB_DIR}
-  ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
-)
+  set(DEF_INSTALL_CMAKE_DIR lib/cmake/rttest)
+  set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "install dir for cmake files")
 
-install(FILES ${PROJECT_SOURCE_DIR}/include/rttest/rttest.h ${PROJECT_SOURCE_DIR}/include/rttest/utils.h DESTINATION ${INSTALL_INCLUDE_DIR})
+  add_library(rttest ${PROJECT_SOURCE_DIR}/src/rttest.cpp)
 
-export(PACKAGE ${PROJECT_NAME})
+  include_directories(rttest ${PROJECT_SOURCE_DIR}/include/rttest)
 
-set(rttest_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
-set(rttest_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
-set(rttest_CMAKE_DIR
-  ${CMAKE_INSTALL_PREFIX}/share/${CMAKE_PROJECT_NAME}/CMake)
-configure_file(${CMAKE_PROJECT_NAME}Config.cmake.in
-  ${CMAKE_BINARY_DIR}/InstallFiles/${CMAKE_PROJECT_NAME}Config.cmake
-  @ONLY)
-install(FILES
-  ${CMAKE_BINARY_DIR}/InstallFiles/${CMAKE_PROJECT_NAME}Config.cmake
-  DESTINATION ${rttest_CMAKE_DIR})
+  install(TARGETS rttest
+    LIBRARY DESTINATION ${INSTALL_LIB_DIR}
+    ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
+  )
+
+  install(FILES ${PROJECT_SOURCE_DIR}/include/rttest/rttest.h ${PROJECT_SOURCE_DIR}/include/rttest/utils.h DESTINATION ${INSTALL_INCLUDE_DIR})
+
+  export(PACKAGE ${PROJECT_NAME})
+
+  set(rttest_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
+  set(rttest_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+  set(rttest_CMAKE_DIR
+    ${CMAKE_INSTALL_PREFIX}/share/${CMAKE_PROJECT_NAME}/CMake)
+  configure_file(${CMAKE_PROJECT_NAME}Config.cmake.in
+    ${CMAKE_BINARY_DIR}/InstallFiles/${CMAKE_PROJECT_NAME}Config.cmake
+    @ONLY)
+  install(FILES
+    ${CMAKE_BINARY_DIR}/InstallFiles/${CMAKE_PROJECT_NAME}Config.cmake
+    DESTINATION ${rttest_CMAKE_DIR})
+
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,28 @@ project(rttest)
 
 set(CMAKE_CXX_FLAGS "-std=c++11")
 
-find_package(ament_cmake_auto QUIET)
+find_package(ament_cmake QUIET)
 
 # ament build if it was found
-if(${ament_cmake_auto_FOUND})
-  ament_auto_find_build_dependencies()
-  ament_auto_add_library(rttest ${PROJECT_SOURCE_DIR}/src/rttest.cpp)
+if(${ament_cmake_FOUND})
   include_directories(rttest ${PROJECT_SOURCE_DIR}/include/rttest)
-  #ament_auto_package(CONFIG_EXTRAS ${CMAKE_PROJECT_NAME}Config.cmake)
+  add_library(rttest ${PROJECT_SOURCE_DIR}/src/rttest.cpp)
+  target_link_libraries(rttest m stdc++)
+
+  ament_export_include_directories(include)
+  ament_export_libraries(rttest)
+
+  ament_package()
+
+  install(
+    DIRECTORY include/
+    DESTINATION include
+  )
+  install(
+    TARGETS rttest
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+  )
 
 else()
   message(STATUS "ament_cmake_auto not found, executing pure CMake build")

--- a/scripts/get_average_jitter.py
+++ b/scripts/get_average_jitter.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+# measure average jitter of an executable
+# get_average_jitter.py <iterations> executable <rttest args>
+
+# Run the executable <iterations> times
+# get min from "Min: <min>"
+# get max from "Max: <max>"
+# get mean from "Mean: <mean>"
+# get stddev from "Standard deviation: <stddev>
+
+# Keep a running tally and average over <iterations>
+
+from __future__ import print_function
+import re
+import subprocess
+import sys
+from sys import argv
+
+if len(argv) < 3:
+    print("get_average_jitter requires at least 3 arguments.", file=sys.stderr)
+    exit(1)
+
+iterations = int(argv[1])
+command = argv[2:]
+
+keys = ["Min", "Max", "Mean", "Standard deviation"]
+
+tally = dict(zip(keys, [0.0]*len(keys)))
+
+for i in range(iterations):
+    stdoutput = subprocess.check_output(command)
+    # Split on double newline
+    print(stdoutput)
+    outputs = stdoutput.split('\n\n')
+
+    for output in outputs:
+        for key in keys:
+            match = re.search('(?<='+key+': )\w+', output)
+            if match is not None:
+                tally[key] += float(match.group())
+
+# get averages
+for key in keys:
+    average = tally[key]/iterations
+    print("Average {}: {}".format(key, str(average)))
+

--- a/scripts/get_average_jitter.py
+++ b/scripts/get_average_jitter.py
@@ -24,7 +24,7 @@ if len(argv) < 3:
 iterations = int(argv[1])
 command = argv[2:]
 
-keys = ["Min", "Max", "Mean", "Standard deviation"]
+keys = ["Minor pagefaults", "Major pagefaults", "Min", "Max", "Mean", "Standard deviation"]
 
 tally = dict(zip(keys, [0.0]*len(keys)))
 

--- a/src/rttest.cpp
+++ b/src/rttest.cpp
@@ -666,7 +666,6 @@ extern "C"
     }
     sstring << "  - Minor pagefaults: " << results->minor_pagefaults << std::endl;
     sstring << "  - Major pagefaults: " << results->major_pagefaults << std::endl;
-    sstring << std::endl;
     sstring << "  Latency (time after deadline was missed):" << std::endl;
     sstring << "    - Min: " << results->min_latency << std::endl;
     sstring << "    - Max: " << results->max_latency << std::endl;

--- a/src/rttest.cpp
+++ b/src/rttest.cpp
@@ -66,7 +66,7 @@ extern "C"
 
       int init(unsigned int iterations, struct timespec update_period,
           size_t sched_policy, int sched_priority, int lock_memory, size_t stack_size,
-          int plot, char *filename, unsigned int repetitions);
+          char *filename);
 
       int spin(void *(*user_function)(void *), void *args);
 
@@ -156,8 +156,6 @@ extern "C"
     struct timespec update_period;
     update_period.tv_sec = 0;
     update_period.tv_nsec = 1000000;
-    // -p,--plot
-    int plot = 0;
     // -t,--thread-priority
     int sched_priority = 80;
     // -s,--sched-policy
@@ -169,8 +167,6 @@ extern "C"
     // -f,--filename
     // Don't write a file unless filename specified
     char *filename = NULL;
-    // -r, --repeat
-    unsigned int repetitions = 1;
     int index;
     int c;
 
@@ -208,9 +204,6 @@ extern "C"
 
             long_to_timespec(nsec, &update_period);
           }
-          break;
-        case 'p':
-          plot = 1;
           break;
         case 't':
           sched_priority = atoi(optarg);
@@ -263,9 +256,6 @@ extern "C"
           fprintf(stderr, "Writing results to file: %s\n", filename);
           // check if file exists
           break;
-        case 'r':
-          repetitions = atoi(optarg);
-          break;
         case '?':
           if (args_string.find(optopt) != std::string::npos)
             fprintf(stderr, "Option -%c requires an argument.\n", optopt);
@@ -280,7 +270,7 @@ extern "C"
     }
 
     this->init(iterations, update_period, sched_policy, sched_priority,
-        lock_memory, stack_size, plot, filename, repetitions);
+        lock_memory, stack_size, filename);
   }
 
   int rttest_init_new_thread()
@@ -325,7 +315,7 @@ extern "C"
 
   int Rttest::init(unsigned int iterations, struct timespec update_period,
       size_t sched_policy, int sched_priority, int lock_memory, size_t stack_size,
-      int plot, char *filename, unsigned int repetitions)
+      char *filename)
   {
     this->params.iterations = iterations;
     this->params.update_period = update_period;
@@ -333,10 +323,8 @@ extern "C"
     this->params.sched_priority = sched_priority;
     this->params.lock_memory = lock_memory;
     this->params.stack_size = stack_size;
-    this->params.plot = plot;
 
     this->params.filename = filename;
-    this->params.reps = repetitions;
 
     this->initialize_dynamic_memory();
 
@@ -365,7 +353,7 @@ extern "C"
 
   int rttest_init(unsigned int iterations, struct timespec update_period,
       size_t sched_policy, int sched_priority, int lock_memory, size_t stack_size,
-      int plot, char *filename, unsigned int repetitions)
+      char *filename)
   {
     auto thread_id = pthread_self();
     auto thread_rttest_instance = get_rttest_thread_instance(thread_id);
@@ -379,8 +367,7 @@ extern "C"
       }
     }
     return thread_rttest_instance->init(iterations, update_period,
-      sched_policy, sched_priority, lock_memory, stack_size,
-      plot, filename, repetitions);
+      sched_policy, sched_priority, lock_memory, stack_size, filename);
   }
 
   int Rttest::get_next_rusage(unsigned int i)


### PR DESCRIPTION
initial implementation of the header laid out in the master branch.

Some highlights:

See "examples/example_loop" for a common usage of this library.

Argument parsing and initial memory allocation is taken care in `rttest_read_args`.

The code to be instrumented is passed as a function pointer to `rttest_spin`, which calls the function and measures scheduling jitter and pagefaults in a real-time safe way.

Teardown happens in `rttest_finish`.

`rttest` keeps track of statistics and stores parameters for different threads, but the interface to rttest does not expose the thread. It keeps an internal struct to check the thread id of the calling thread and gets/sets data for that thread accordingly.